### PR TITLE
Better Prevent Consecutive Repeat

### DIFF
--- a/src/konamicode.c
+++ b/src/konamicode.c
@@ -39,7 +39,7 @@ static void gen_konami_sequence() {
     int nRetry = 5;
     do {
       s_konami_sequence[i] = rand() % KC_Max;
-    } while ((i > 0) && (nRetry-- > 0) && (s_konami_sequence[i] == s_konami_sequence[i - 1]))
+    } while ((i > 0) && (--nRetry > 0) && (s_konami_sequence[i] == s_konami_sequence[i - 1]))
 
     // Special Case -- If we've exceeded our max retry in preventing a consecutive repeat
     // in the sequence, then just shift 1 code over from the previous code in the sequence.

--- a/src/konamicode.c
+++ b/src/konamicode.c
@@ -38,7 +38,7 @@ static void gen_konami_sequence() {
     // Prevent Consecutive-Repeats:
     // If the current code in the sequence matches the previous code
     // then regenerate the code for the current position
-    if ((i > 0) && (s_konami_sequence[i] == s_konami_sequence[i = 1])) {
+    if ((i > 0) && (s_konami_sequence[i] == s_konami_sequence[i - 1])) {
       i--;
     }
   }

--- a/src/konamicode.c
+++ b/src/konamicode.c
@@ -21,7 +21,8 @@ static CodeSuccessCallBack s_success_event = NULL;
 enum KonamiCodes {
   KC_Up = 0,
   KC_Right = 1,
-  KC_Down = 2
+  KC_Down = 2,
+  KC_Max = 3
 };
 
 static enum KonamiCodes s_konami_sequence[5];
@@ -33,13 +34,17 @@ static void gen_konami_sequence() {
   srand(time(NULL));
   
   for (int i = 0; i < 5; i++) {
-    s_konami_sequence[i] = rand() % 3;
-    
-    // Prevent Consecutive-Repeats:
-    // If the current code in the sequence matches the previous code
-    // then regenerate the code for the current position
+    // Re-generate the code until it's not a consecutive repeat from the previous
+    // code in the sequence (with a retry upto 5 times).
+    int nRetry = 5;
+    do {
+      s_konami_sequence[i] = rand() % KC_Max;
+    } while ((i > 0) && (nRetry-- > 0) && (s_konami_sequence[i] == s_konami_sequence[i - 1]))
+
+    // Special Case -- If we've exceeded our max retry in preventing a consecutive repeat
+    // in the sequence, then just shift 1 code over from the previous code in the sequence.
     if ((i > 0) && (s_konami_sequence[i] == s_konami_sequence[i - 1])) {
-      i--;
+      s_konami_sequence[i] = (s_konami_sequence[i - 1] + 1) % KC_Max;
     }
   }
   

--- a/src/konamicode.c
+++ b/src/konamicode.c
@@ -34,6 +34,13 @@ static void gen_konami_sequence() {
   
   for (int i = 0; i < 5; i++) {
     s_konami_sequence[i] = rand() % 3;
+    
+    // Prevent Consecutive-Repeats:
+    // If the current code in the sequence matches the previous code
+    // then regenerate the code for the current position
+    if ((i > 0) && (s_konami_sequence[i] == s_konami_sequence[i = 1])) {
+      i--;
+    }
   }
   
 }


### PR DESCRIPTION
Max retry of 5 times, if we exceed that retry, then we simply shift 1 code value from the previous code in the sequence.  This still guarantees no Consecutive-Repeats, just not as "random" in the HIGHLY unlikely case that we've retried 5 times without success.
